### PR TITLE
Our 388

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Forum/LatestActivity.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Forum/LatestActivity.cshtml
@@ -19,7 +19,7 @@
         var cat = Umbraco.TypedContent(topic.ParentId);
         var mem = Members.GetById(topic.LatestReplyAuthor) ?? Members.GetById(topic.MemberId);
 
-        <a href="@topic.GetUrl()" class="forum-thread">
+        <a href="@topic.GetUrl()" class="forum-thread @Umbraco.If(topic.Answer > 0, " solved")">
 
             <div class="avatar">
 				@if(mem != null)

--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ListProjects.cshtml
@@ -114,7 +114,7 @@
     <div class="box">
         <div class="row">
             <div class="col-xs-2 col-md-1">
-                <img src="{{image}}" alt="">
+                <img src="{{image}}?bgcolor=fff&width=50&height=50&format=png" alt="">
             </div>
             <div class="col-xs-10 col-md-6">
                 <div class="forum-thread-text">


### PR DESCRIPTION
http://issues.umbraco.org/issue/OUR-388

In the initial project listing, the images are set to
"?bgcolor=fff&width=50&height=50&format=png" but in the search listing a
little bit further up in the same file, the images are not restricted to
any size. That made Internet Explorer and Firefox go bananas, but for
some reason not Chrome.
Setting the same queries on the search listing fixes this.
